### PR TITLE
Fix #35. 

### DIFF
--- a/src/LetsEncrypt.Azure.Core.V2/LetsEncrypt.Azure.Core.V2.csproj
+++ b/src/LetsEncrypt.Azure.Core.V2/LetsEncrypt.Azure.Core.V2.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Certes" Version="2.3.3" />
+    <PackageReference Include="Certes" Version="3.0.4" />
     <PackageReference Include="DnsClient" Version="1.2.0" />
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.3" />
     <PackageReference Include="Microsoft.Azure.Management.AppService.Fluent" Version="1.13.0" />
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.0.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Fix LetsEncrypt.Azure.Core.V2 by upgrading Certes lib.